### PR TITLE
Keystore 2.0: Add CREATION_DATETIME only for Keymint V1 and higher.

### DIFF
--- a/keystore2/src/security_level.rs
+++ b/keystore2/src/security_level.rs
@@ -405,23 +405,26 @@ impl KeystoreSecurityLevel {
             );
         }
 
-        result.push(KeyParameter {
-            tag: Tag::CREATION_DATETIME,
-            value: KeyParameterValue::DateTime(
-                SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .context(
-                        "In KeystoreSecurityLevel::add_required_parameters: \
+        // Add CREATION_DATETIME only if the backend version Keymint V1 (100) or newer.
+        if self.hw_info.versionNumber >= 100 {
+            result.push(KeyParameter {
+                tag: Tag::CREATION_DATETIME,
+                value: KeyParameterValue::DateTime(
+                    SystemTime::now()
+                        .duration_since(SystemTime::UNIX_EPOCH)
+                        .context(
+                            "In KeystoreSecurityLevel::add_required_parameters: \
                         Failed to get epoch time.",
-                    )?
-                    .as_millis()
-                    .try_into()
-                    .context(
-                        "In KeystoreSecurityLevel::add_required_parameters: \
+                        )?
+                        .as_millis()
+                        .try_into()
+                        .context(
+                            "In KeystoreSecurityLevel::add_required_parameters: \
                         Failed to convert epoch time.",
-                    )?,
-            ),
-        });
+                        )?,
+                ),
+            });
+        }
 
         // If there is an attestation challenge we need to get an application id.
         if params.iter().any(|kp| kp.tag == Tag::ATTESTATION_CHALLENGE) {


### PR DESCRIPTION
Adding CREATION_DATETIME unconditionally should be accepted by all
keymaster implementations. Alas, VTS tests never covered this before
Keymint V1 and so there are implementations that fail when the caller
presents the tag.

Test: CtsKeystoreTestCases for regression testing.
Bug: 210792876
Bug: 204578637
Change-Id: I3cf7e8def7a369839844ef1b3628f477d8fe6b53